### PR TITLE
Adds the language attribute to provide better UX and a11y

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -120,7 +120,7 @@ class syntax_plugin_wikipediasnippet extends DokuWiki_Syntax_Plugin {
         $langParams = $this->_getLangParams($articleLang);
 
         // display snippet and container
-        $wpContent  = '<dl class="wpsnip">'.NL;
+        $wpContent  = '<dl class="wpsnip" lang="'.$articleLang.'">'.NL;
         $wpContent .= '  <dt>'.NL;
         $wpContent .= '    <em>'.sprintf($this->getLang('from'), $wpUrl).'<span>: </span></em>';
         $wpContent .=      '<cite><strong><a href="'.$articleLink.'" class="interwiki iw_wp">'.$title.'</a></strong></cite> ';


### PR DESCRIPTION
An author may choose to use a different language than the wiki/page for the snippet that is retrieved from Wikipedia using the `{{wp:<lang>>topic}}` syntax.
Adding the `lang` attribute to the `dl` element provides a hint to users (and eg. screenreaders) about the language change.
